### PR TITLE
Fix date-only strings in date operators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "directus-auto-gen-extension",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "directus-auto-gen-extension",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "gpl-3.0",
       "dependencies": {
         "vue-i18n": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-auto-gen-extension",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "type": "module",
   "description": "Perform computed value based on other fields",
   "author": {

--- a/src/operations.test.ts
+++ b/src/operations.test.ts
@@ -76,12 +76,26 @@ describe('Test parseExpression', () => {
       expect(parseExpression('YEAR($NOW)', {})).toBe(new Date().getFullYear());
     });
 
+    test('YEAR op supports Directus date-only strings', () => {
+      expect(parseExpression('YEAR(date_of_birth)', { date_of_birth: '2000-01-01' })).toBe(2000);
+    });
+
     test('MONTH op', () => {
       expect(parseExpression('MONTH($NOW)', {})).toBe(new Date().getMonth());
     });
 
     test('GET_DATE op', () => {
       expect(parseExpression('GET_DATE($NOW)', {})).toBe(new Date().getDate());
+    });
+
+    test('date ops support date-like strings without DATE wrapper', () => {
+      expect(parseExpression('MONTH(date_of_birth)', { date_of_birth: '2000-02-03' })).toBe(1);
+      expect(parseExpression('GET_DATE(date_of_birth)', { date_of_birth: '2000-02-03' })).toBe(3);
+    });
+
+    test('date ops preserve invalid date fallback', () => {
+      expect(parseExpression('YEAR(date_of_birth)', { date_of_birth: 'not-a-date' })).toBe(0);
+      expect(parseExpression('YEAR(date_of_birth)', { date_of_birth: null })).toBe(0);
     });
 
     test('DAY op', () => {

--- a/src/shared/evaluator.ts
+++ b/src/shared/evaluator.ts
@@ -132,7 +132,8 @@ function _parseExpression(
                     return `${hours}:${minutes}:${seconds}`;
                 }
                 if (['YEAR', 'MONTH', 'GET_DATE', 'DAY', 'HOURS', 'MINUTES', 'SECONDS', 'TIME'].includes(op)) {
-                    if (valueA instanceof Date) {
+                    const date = coerceDate(valueA);
+                    if (date) {
                         const op2func: Record<string, keyof Date> = {
                             YEAR: 'getFullYear',
                             MONTH: 'getMonth',
@@ -144,7 +145,7 @@ function _parseExpression(
                             TIME: 'getTime',
                         };
                         // @ts-ignore
-                        return valueA[op2func[op]]();
+                        return date[op2func[op]]();
                     }
                     return 0;
                 }
@@ -661,6 +662,27 @@ function isCountRow(value: unknown): value is { value: unknown; count: number } 
         typeof (value as { count?: unknown }).count === 'number' &&
         Number.isFinite((value as { count: number }).count)
     );
+}
+
+function coerceDate(value: unknown): Date | null {
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value;
+    }
+    if (typeof value === 'string') {
+        const dateOnly = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+        if (dateOnly) {
+            const [, year, month, day] = dateOnly;
+            const date = new Date(Number(year), Number(month) - 1, Number(day));
+            return Number.isNaN(date.getTime()) ? null : date;
+        }
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? null : date;
+    }
+    if (typeof value === 'number') {
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? null : date;
+    }
+    return null;
 }
 
 export const toSlug = (value: unknown): string => {


### PR DESCRIPTION
## Summary

Fixes #23 by allowing the existing unary date operators to work with Directus Date-only field values such as `2000-01-01` without requiring a `DATE(...)` wrapper.

This is intentionally scoped to the current date operator block. It does not add formula syntax, introduce a date library, redesign the evaluator, or change the behavior of the broader date formatting/conversion operators.

## Root Cause

The evaluator's unary date operators (`YEAR`, `MONTH`, `GET_DATE`, `DAY`, `HOURS`, `MINUTES`, `SECONDS`, and `TIME`) only executed when the resolved value was already a JavaScript `Date` instance. Directus Date-only fields are passed through as strings, so `YEAR(date_of_birth)` resolved `date_of_birth` to a string like `2000-01-01`, skipped the date getter block, and returned the existing fallback value of `0`.

## What Changed

- Added a small `coerceDate` helper inside `src/shared/evaluator.ts`.
- Updated only the existing unary date operator block to call date getters on the coerced value.
- Preserved the `0` fallback for invalid or unsupported values.
- Parsed `YYYY-MM-DD` strings manually as local dates to avoid timezone shifts from `new Date("YYYY-MM-DD")`.
- Added focused regression tests for Directus date-only strings, date-like strings without `DATE(...)`, and invalid input fallback behavior.
- Bumped the package version from `3.5.0` to `3.5.1` for patch release publishing after merge.

## Release Impact

This patch is intended for npm publish after merge as version `3.5.1`. It is a compatibility bug fix for existing documented operators, not a public formula syntax change.

## Branch Note

This PR still uses the existing head branch `codex/date-only-operator-coercion`. GitHub does not provide a low-risk way to rename a PR head branch in place, so I left PR #24 intact instead of risking disruption. Future branches for this repo should avoid the `codex/` prefix.

## Validation

- `git diff --check` passed.
- Attempted `npx jest src/operations.test.ts --runInBand`; the command again entered the existing validation-idle state tracked by issue #22 and produced no test output after more than a minute, so it was stopped without making unrelated validation-system changes.
