### PR TITLE
Add manual npm publish workflow trigger

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -4,7 +4,8 @@ name: npm publish
 
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

This updates the npm publish workflow trigger so package publishing can be started intentionally when a merge to `main` does not run the publish job.

## Why

Merging PR #24 bumped the package version to `3.5.1`, but the npm publish workflow did not run because the workflow is triggered only by GitHub Release events. A merge to `main` is not a release event, so it will not publish the package.

## What Changed

- Kept the GitHub Release trigger for npm publishing.
- Normalized the release event from `created` to `published`, matching the normal published-release flow.
- Added `workflow_dispatch` so maintainers can manually run the publish workflow from the Actions tab as a safe fallback.

## Notes

No npm publishing strategy, build step, or test step was changed. The existing `npm test -- --runInBand` step remains in place despite the known validation-idle behavior tracked by issue #22.

After this PR merges, maintainers can publish `v3.5.1` by either creating/publishing the GitHub Release or manually running this workflow from the Actions tab.

## Validation

- `git diff --check` passed.
